### PR TITLE
Replaced trapezoid integrator

### DIFF
--- a/stsynphot/spectrum.py
+++ b/stsynphot/spectrum.py
@@ -52,13 +52,13 @@ def _interp_spec(interpval, waves, lower_val, upper_val, lower_thru,
     interpval : float
         Desired parameter value.
 
-    waves : array_like
+    waves : array-like
         Wavelengths for all the parameterized spectra.
 
     lower_val, upper_val : float
         Low and high values of parameter to interpolate.
 
-    lower_thru, upper_thru : array_like
+    lower_thru, upper_thru : array-like
         Throughput values are ``lower_val`` and ``upper_val``.
 
     doshift : bool
@@ -66,7 +66,7 @@ def _interp_spec(interpval, waves, lower_val, upper_val, lower_thru,
 
     Returns
     -------
-    thru : array_like
+    thru : array-like
         Interpolated throughput at ``interpval``.
 
     """
@@ -282,7 +282,7 @@ class ObservationSpectralElement(SpectralElement):
 
         Parameters
         ----------
-        wavelengths : array_like, `~astropy.units.quantity.Quantity`, or `None`
+        wavelengths : array-like, `~astropy.units.quantity.Quantity`, or `None`
             Wavelength values for sampling.
             If not a Quantity, assumed to be in Angstrom.
             If `None`, ``self.waveset`` is used.
@@ -458,7 +458,7 @@ class ObservationSpectralElement(SpectralElement):
         filename : str
             Output filename.
 
-        wavelengths : array_like, `~astropy.units.quantity.Quantity`, or `None`
+        wavelengths : array-like, `~astropy.units.quantity.Quantity`, or `None`
             Wavelength values for sampling.
             If not a Quantity, assumed to be in Angstrom.
             If `None`, ``self.waveset`` is used.

--- a/stsynphot/tests/test_spectrum.py
+++ b/stsynphot/tests/test_spectrum.py
@@ -21,7 +21,6 @@ from astropy.utils.data import get_pkg_data_filename
 # SYNPHOT
 from synphot import units
 from synphot import exceptions as synexceptions
-from synphot.integrator import TrapezoidIntegrator
 from synphot.models import ConstFlux1D
 from synphot.spectrum import SourceSpectrum, SpectralElement
 
@@ -197,7 +196,7 @@ class TestObservationSpectralElement(object):
 
         # Unit response
         a = obs.unit_response(obs.area)
-        b = units.HC * 0.01 / TrapezoidIntegrator()._raw_math(x, x * y)
+        b = units.HC * 0.01 / abs(np.trapz(x * y, x=x))
         np.testing.assert_allclose(a.value, b.value)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Replaced trapezoid integrator with `np.trapz()`. Replaced "array_like" with "array-like" in docstrings. This brings `stsynphot` up-to-date with spacetelescope/synphot_refactor#87.