### PR TITLE
Use new Empirical1D that uses new Tabular model

### DIFF
--- a/stsynphot/observationmode.py
+++ b/stsynphot/observationmode.py
@@ -429,7 +429,8 @@ class ObservationMode(BaseObservationMode):
         y = self.throughput(x)
         thru = y.value * x.value * self._constant.value
         meta = {'expr': 'Sensitivity for {0}'.format(self._obsmode)}
-        return SpectralElement(Empirical1D, x=x, y=thru, meta=meta)
+        return SpectralElement(
+            Empirical1D, points=x, lookup_table=thru, meta=meta)
 
     def thermal_spectrum(self, thermtable=None):
         """Calculate thermal spectrum using
@@ -617,4 +618,4 @@ class ThermalObservationMode(BaseObservationMode):
                 y += component.emissivity.thermal_source()(x).value  # PHOTLAM
 
         meta = {'expr': '{0} ThermalSpectrum'.format(self._obsmode)}
-        return SourceSpectrum(Empirical1D, x=x, y=y, meta=meta)
+        return SourceSpectrum(Empirical1D, points=x, lookup_table=y, meta=meta)

--- a/stsynphot/spectrum.py
+++ b/stsynphot/spectrum.py
@@ -213,7 +213,8 @@ def interpolate_spectral_element(parfilename, interpval, ext=1):
 
     meta = {'expr': '{0}#{1:g}'.format(filename, interpval),
             'warnings': warndict}
-    return SpectralElement(Empirical1D, x=wave0*wave_unit, y=thru, meta=meta)
+    return SpectralElement(
+        Empirical1D, points=wave0*wave_unit, lookup_table=thru, meta=meta)
 
 
 class ObservationSpectralElement(SpectralElement):


### PR DESCRIPTION
Use new `Empirical1D` that uses Nadia's new `Tabular` model.

TODO:

- [x] Run tests after astropy/astropy#5105 and spacetelescope/synphot_refactor#92 are merged. They already passed on local machine.