### PR TITLE
Backward compatible catalog names

### DIFF
--- a/stsynphot/catalog.py
+++ b/stsynphot/catalog.py
@@ -119,10 +119,10 @@ def grid_to_spec(gridname, t_eff, metallicity, log_g):
 
     Parameters
     ----------
-    gridname : {'ck04', 'k93', 'phoenix'}
+    gridname : {'ck04models', 'k93models', 'phoenix'}
         Model to use:
-            * ``ck04`` - Castelli & Kurucz (2004)
-            * ``k93`` - Kurucz (1993)
+            * ``ck04models`` - Castelli & Kurucz (2004)
+            * ``k93models`` - Kurucz (1993)
             * ``phoenix`` - Allard et al. (2009)
 
     t_eff : str, float or `astropy.units.quantity.Quantity`
@@ -152,9 +152,9 @@ def grid_to_spec(gridname, t_eff, metallicity, log_g):
         Invalid inputs.
 
     """
-    if gridname == 'ck04':
+    if gridname == 'ck04models':
         catdir = 'crgridck04$'
-    elif gridname == 'k93':
+    elif gridname == 'k93models':
         catdir = 'crgridk93$'
     elif gridname == 'phoenix':
         catdir = 'crgridphoenix$'

--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -20,7 +20,7 @@ from .. import catalog, exceptions
 @remote_data
 def test_grid_to_spec():
     """Test creating spectrum from grid, and related cache."""
-    sp = catalog.grid_to_spec('k93', 6440, 0, 4.3)
+    sp = catalog.grid_to_spec('k93models', 6440, 0, 4.3)
     w = sp.waveset
     w_first_50 = w[:50]
     y_first_50 = units.convert_flux(w_first_50, sp(w_first_50), units.FLAM)
@@ -86,7 +86,7 @@ def test_grid_to_spec():
 def test_grid_to_spec_bounds_check(t, m, g):
     """Test out of bounds check."""
     with pytest.raises(exceptions.ParameterOutOfBounds):
-        sp = catalog.grid_to_spec('k93', t, m, g)
+        sp = catalog.grid_to_spec('k93models', t, m, g)
 
 
 def test_grid_to_spec_exceptions():
@@ -98,7 +98,7 @@ def test_grid_to_spec_exceptions():
     # Quantity is not acceptable for log values
     with pytest.raises(synexceptions.SynphotError):
         sp = catalog.grid_to_spec(
-            'k93', 6440, 0 * u.dimensionless_unscaled, 4.3)
+            'k93models', 6440, 0 * u.dimensionless_unscaled, 4.3)
     with pytest.raises(synexceptions.SynphotError):
         sp = catalog.grid_to_spec(
-            'k93', 6440, 0, 4.3 * u.dimensionless_unscaled)
+            'k93models', 6440, 0, 4.3 * u.dimensionless_unscaled)

--- a/stsynphot/tests/test_parser.py
+++ b/stsynphot/tests/test_parser.py
@@ -56,12 +56,13 @@ def test_single_functioncall(input_str, ans_cls, ans_model):
     ('input_str', 'ans_cls', 'ans_model'),
     [('spec(crcalspec$alpha_lyr_stis_007.fits)', SourceSpectrum, Empirical1D),
      ('band(v)', spectrum.ObservationSpectralElement, Empirical1D),
-     ('icat(k93, 5000, 0.5, 0)', SourceSpectrum, None),
+     ('icat(k93models, 5000, 0.5, 0)', SourceSpectrum, None),
      ('ebmvx(0.3, mwavg)', ExtinctionCurve, Empirical1D),
      ('rn(crcalspec$gd71_mod_005.fits, box(5000, 10), 17, vegamag)',
       SourceSpectrum, None),
-     ('rn(icat(k93, 5000, 0.5, 0), cracscomp$acs_f814w_hrc_006_syn.fits, '
-      '17, obmag)', SourceSpectrum, None),
+     ('rn(icat(k93models, 5000, 0.5, 0), '
+      'cracscomp$acs_f814w_hrc_006_syn.fits, 17, obmag)',
+      SourceSpectrum, None),
      ('rn(pl(5000, 1, flam), band(v), 1, photlam)',
       SourceSpectrum, None),
      ('rn(unit(1,flam), band(acs, wfc1, fr388n#3881.0), 10, abmag)',


### PR DESCRIPTION
Changed catalog names to be consistent with ASTROLIB PYSYNPHOT so that the same `parse_spec()` string works for both when creating an interpolated spectrum.