### PR TITLE
Fix pysynphot OBSMODE limitations

### DIFF
--- a/stsynphot/commissioning/utils.py
+++ b/stsynphot/commissioning/utils.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 # STDLIB
+import os
 import sys
 from collections import Iterable
 
@@ -77,9 +78,10 @@ class CommCase(object):
     force = None
 
     # Default tables are the latest available as of 2016-07-25.
-    tables = {'graphtable': 'mtab$07r1502mm_tmg.fits',
-              'comptable': 'mtab$07r1502nm_tmc.fits',
-              'thermtable': 'mtab$tae17277m_tmt.fits'}
+    tables = {
+        'graphtable': os.path.join('mtab$OLD_FILES', '07r1502mm_tmg.fits'),
+        'comptable': os.path.join('mtab$OLD_FILES', '07r1502nm_tmc.fits'),
+        'thermtable': 'mtab$tae17277m_tmt.fits'}
 
     def setup_class(self):
         """Subclass needs to define ``obsmode`` and ``spectrum``

--- a/stsynphot/observationmode.py
+++ b/stsynphot/observationmode.py
@@ -379,6 +379,11 @@ class ObservationMode(BaseObservationMode):
 
         for throughput_name in self._throughput_filenames:
             parkey = self._parkey_from_filename(throughput_name)
+
+            # Hack for WFPC2 ramp filters
+            if parkey == 'wave' and self.modes[0] == 'wfpc2':
+                parkey = 'lrf'
+
             cdict_key = (throughput_name, self.pardict.get(parkey))
 
             if cdict_key not in self._component_dict:

--- a/stsynphot/tables.py
+++ b/stsynphot/tables.py
@@ -179,8 +179,6 @@ class GraphTable(object):
             # Find the entry corresponding to the component named
             # 'default', because thats the one we'll use if we don't
             # match anything in the modes list
-            defaultindex = np.where(self.keywords[nodes] == 'default')
-
             if 'default' in self.keywords[nodes]:
                 dfi = np.where(self.keywords[nodes] == 'default')[0][0]
                 outnode = self.outnodes[nodes[0][dfi]]
@@ -225,7 +223,8 @@ class GraphTable(object):
 
         if outnode < 0:
             log.debug('outnode={0} (stop condition)'.format(outnode))
-            raise exceptions.IncompleteObsmode('{0}'.format(modes))
+            raise exceptions.IncompleteObsmode(
+                '{0}, choose from {1}'.format(modes, self.keywords[nodes]))
 
         if inmodes != used_modes:
             raise exceptions.UnusedKeyword(


### PR DESCRIPTION
Finally got around to fixing two outstanding issues that still exist in Astrolib PySynphot:

- [x] List possible options for user when obsmode provided is incomplete.
- [x] Add a hack so obsmode for WFPC2 `lrf#` modes can be parsed correctly.