### PR TITLE
Use system pytest and update astropy-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        #- ASTROPY_VERSION=stable
-        - ASTROPY_VERSION=development
+        - ASTROPY_VERSION=stable
         - SYNPHOT_VERSION=development
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
@@ -35,7 +34,7 @@ env:
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
         #- CONDA_DEPENDENCIES='Cython'
-        - CONDA_DEPENDENCIES='Cython jinja2 scipy'
+        - CONDA_DEPENDENCIES='Cython jinja2 scipy pytest'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
@@ -46,22 +45,19 @@ env:
 matrix:
     include:
 
-        # Do a coverage test in Python 2.
-        - python: 2.7
+        # Do a coverage test in Python 3.
+        - python: 3.5
           env: SETUP_CMD='test --coverage'
 
         # DISABLED FOR NOW
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        #- python: 2.7
+        #- python: 3.5
         #  env: SETUP_CMD='build_sphinx -w'
 
-        # DISABLED FOR NOW
         # Try Astropy development version
-        #- python: 2.7
-        #  env: ASTROPY_VERSION=development
-        #- python: 3.5
-        #  env: ASTROPY_VERSION=development
+        - python: 3.6
+          env: ASTROPY_VERSION=development
 
         # Do a PEP8 test with pycodestyle
         - python: 3.5
@@ -88,7 +84,7 @@ install:
     # commands in the install: section below.
 
     - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - source ci-helpers/travis/setup_conda.sh
 
     # Upgrade to the latest version of pip to avoid it displaying warnings
     # about it being out of date.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,13 +18,13 @@ environment:
 
   matrix:
 
-      # We test Python 2.7 and 3.5
+      # We test Python 2.7 and 3.6
 
       - PYTHON_VERSION: "2.7"
-        ASTROPY_VERSION: "development"
+        ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 
-      - PYTHON_VERSION: "3.5"
+      - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "development"
         NUMPY_VERSION: "stable"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,8 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.2
+[tool:pytest]
+minversion = 3.0
 norecursedirs = build docs/_build stsynphot/data
 
 [ah_bootstrap]

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setup(name=PACKAGENAME,
       description=DESCRIPTION,
       scripts=scripts,
       install_requires=['numpy', 'astropy'],  # 'numpy>=1.9', 'astropy>=1.3', 'scipy>=0.14', 'synphot>=0.1'
+      tests_require=['pytest'],
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,

--- a/stsynphot/commissioning/utils.py
+++ b/stsynphot/commissioning/utils.py
@@ -8,10 +8,11 @@ from collections import Iterable
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
 # ASTROPY
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 
 # ASTROLIB
 try:

--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -4,10 +4,11 @@ from __future__ import absolute_import, division, print_function
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 
 # SYNPHOT
 from synphot import exceptions as synexceptions

--- a/stsynphot/tests/test_config.py
+++ b/stsynphot/tests/test_config.py
@@ -7,9 +7,10 @@ import os
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 
 # SYNPHOT
 from synphot.config import conf as synconf

--- a/stsynphot/tests/test_observationmode.py
+++ b/stsynphot/tests/test_observationmode.py
@@ -7,10 +7,11 @@ import os
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 from astropy.utils.data import get_pkg_data_filename
 
 # SYNPHOT

--- a/stsynphot/tests/test_parser.py
+++ b/stsynphot/tests/test_parser.py
@@ -12,8 +12,11 @@ from __future__ import absolute_import, division, print_function
 # STDLIB
 import os
 
+# THIRD-PARTY
+import pytest
+
 # ASTROPY
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 
 # SYNPHOT
 from synphot import exceptions as synexceptions

--- a/stsynphot/tests/test_spectrum.py
+++ b/stsynphot/tests/test_spectrum.py
@@ -10,12 +10,13 @@ import tempfile
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
 from astropy.io import fits
 from astropy.modeling.models import Const1D
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 from astropy.utils.data import get_pkg_data_filename
 
 # SYNPHOT

--- a/stsynphot/tests/test_stio.py
+++ b/stsynphot/tests/test_stio.py
@@ -13,9 +13,10 @@ import os
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import remote_data
 from astropy.utils.data import _find_pkg_data_path, get_pkg_data_filename
 
 # SYNPHOT

--- a/stsynphot/tests/test_tables.py
+++ b/stsynphot/tests/test_tables.py
@@ -11,9 +11,9 @@ from __future__ import absolute_import, division, print_function
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
-from astropy.tests.helper import pytest
 from astropy.utils.data import get_pkg_data_filename
 
 # SYNPHOT

--- a/stsynphot/tests/test_wavetable.py
+++ b/stsynphot/tests/test_wavetable.py
@@ -4,10 +4,10 @@ from __future__ import absolute_import, division, print_function
 
 # THIRD-PARTY
 import numpy as np
+import pytest
 
 # ASTROPY
 from astropy import units as u
-from astropy.tests.helper import pytest
 
 # LOCAL
 from .. import exceptions


### PR DESCRIPTION
Update Travis, Appveyor, and `astropy-helpers`. Use system `pytest`. Bump `pytest` minversion to 3.

See also spacetelescope/synphot_refactor#122