### PR TITLE
Error when catalog gap used in interpolation

### DIFF
--- a/stsynphot/catalog.py
+++ b/stsynphot/catalog.py
@@ -17,6 +17,7 @@ try:
     from synphot import exceptions as synexceptions
     from synphot import units
     from synphot.spectrum import SourceSpectrum
+    from synphot.utils import validate_totalflux
 except ImportError:  # This is so RTD would build successfully
     pass
 
@@ -81,6 +82,13 @@ def _get_spectrum(parlist, catdir):
 
     filename = os.path.join(catdir, filename)
     sp = SourceSpectrum.from_file(filename, flux_col=column)
+
+    totflux = sp.integrate()
+    try:
+        validate_totalflux(totflux)
+    except synexceptions.SynphotError:
+        raise exceptions.ParameterOutOfBounds(
+            "Parameter '{0}' has no valid data.".format(parlist))
 
     result = [member for member in parlist]
     result.pop()

--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -89,6 +89,18 @@ def test_grid_to_spec_bounds_check(t, m, g):
         catalog.grid_to_spec('k93models', t, m, g)
 
 
+@pytest.mark.remote_data
+def test_phoenix_gap():
+    """
+    https://github.com/spacetelescope/stsynphot_refactor/issues/44
+    """
+    catalog.grid_to_spec('phoenix', 2700, -1, 5.1)  # OK
+    with pytest.raises(exceptions.ParameterOutOfBounds):
+        catalog.grid_to_spec('phoenix', 2700, -0.5, 5.1)
+    with pytest.raises(exceptions.ParameterOutOfBounds):
+        catalog.grid_to_spec('phoenix', 2700, -0.501, 5.1)
+
+
 def test_grid_to_spec_exceptions():
     """Test other exceptions."""
     # Invalid catalog
@@ -102,11 +114,3 @@ def test_grid_to_spec_exceptions():
     with pytest.raises(synexceptions.SynphotError):
         catalog.grid_to_spec(
             'k93models', 6440, 0, 4.3 * u.dimensionless_unscaled)
-
-    # Phoenix gap
-    # https://github.com/spacetelescope/stsynphot_refactor/issues/44
-    catalog.grid_to_spec('phoenix', 2700, -1, 5.1)  # OK
-    with pytest.raises(exceptions.ParameterOutOfBounds):
-        catalog.grid_to_spec('phoenix', 2700, -0.5, 5.1)
-    with pytest.raises(exceptions.ParameterOutOfBounds):
-        catalog.grid_to_spec('phoenix', 2700, -0.501, 5.1)

--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -102,3 +102,11 @@ def test_grid_to_spec_exceptions():
     with pytest.raises(synexceptions.SynphotError):
         catalog.grid_to_spec(
             'k93models', 6440, 0, 4.3 * u.dimensionless_unscaled)
+
+    # Phoenix gap
+    # https://github.com/spacetelescope/stsynphot_refactor/issues/44
+    catalog.grid_to_spec('phoenix', 2700, -1, 5.1)  # OK
+    with pytest.raises(exceptions.ParameterOutOfBounds):
+        catalog.grid_to_spec('phoenix', 2700, -0.5, 5.1)
+    with pytest.raises(exceptions.ParameterOutOfBounds):
+        catalog.grid_to_spec('phoenix', 2700, -0.501, 5.1)


### PR DESCRIPTION
Fix #44 . Same solution as spacetelescope/pysynphot#70 . 

@mgennaro , do you want to take this for a spin and see if this is the fix you were looking for?

**To test this in your conda environment**

If you have previously cloned my fork, you can skip this
```
git clone https://github.com/pllim/stsynphot.git
```

Then
```
git checkout stop-gap
python setup.py install
```