### PR TITLE
MNT: Remove deprecation warning from np.issubdtype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
 
         # Do a test in older Python 3.
         - python: 3.5
-          env: SETUP_CMD='test --open-files'
+          env: SETUP_CMD='test --open-files' SYNPHOT_VERSION=stable
 
         # TODO: Use Astropy lts after 3.0 is out.
         # Do a test in Python 2.
@@ -110,7 +110,8 @@ install:
     # other dependencies.
 
     # SYNPHOT
-    - if [[ $SYNPHOT_VERSION == development ]]; then pip -q install git+http://github.com/spacetelescope/synphot_refactor.git#egg=synphot_refactor; fi
+    - if [[ $SYNPHOT_VERSION == development ]]; then pip -q install git+http://github.com/spacetelescope/synphot_refactor.git#egg=synphot; fi
+    - if [[ $SYNPHOT_VERSION == stable ]]; then pip -q install synphot; fi
 
 script:
     # Only needed for remote data.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ environment:
 
       # We test Python 2.7 and 3.6
 
-      # TODO: Use Astropy lts after 3.0 is out.
       - PYTHON_VERSION: "2.7"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
@@ -42,7 +41,9 @@ install:
     #- "python -m pip install --upgrade pip"
 
     # SYNPHOT (DEV)
-    - "pip -q install git+http://github.com/spacetelescope/synphot_refactor.git#egg=synphot_refactor"
+    #- "pip -q install git+http://github.com/spacetelescope/synphot_refactor.git#egg=synphot"
+    # SYNPHOT (STABLE)
+    - "pip -q install synphot"
 
 # Not a .NET project, we build the package in the install step instead
 build: false

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -3,4 +3,4 @@ scipy>=0.18
 matplotlib
 astropy-helpers
 astropy
--e git+https://github.com/spacetelescope/synphot_refactor.git#egg=synphot
+synphot

--- a/stsynphot/conftest.py
+++ b/stsynphot/conftest.py
@@ -29,6 +29,7 @@ enable_deprecations_as_exceptions()
 try:
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+    PYTEST_HEADER_MODULES['synphot'] = 'synphot'
     del PYTEST_HEADER_MODULES['h5py']
 except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
     pass

--- a/stsynphot/stio.py
+++ b/stsynphot/stio.py
@@ -300,8 +300,8 @@ def read_graphtable(filename, tab_ext=1):
 
     """
     graph_dtypes = {
-        'COMPNAME': np.str, 'KEYWORD': np.str, 'INNODE': np.int,
-        'OUTNODE': np.int, 'THCOMPNAME': np.str, 'COMMENT': np.str}
+        'COMPNAME': np.str_, 'KEYWORD': np.str_, 'INNODE': np.int32,
+        'OUTNODE': np.int32, 'THCOMPNAME': np.str_, 'COMMENT': np.str_}
     data = _read_table(filename, tab_ext, graph_dtypes)
 
     # Get primary area
@@ -355,8 +355,8 @@ def read_comptable(filename, tab_ext=1):
 
     """
     return _read_table(filename, tab_ext,
-                       {'TIME': np.str, 'COMPNAME': np.str,
-                        'FILENAME': np.str, 'COMMENT': np.str})
+                       {'TIME': np.str_, 'COMPNAME': np.str_,
+                        'FILENAME': np.str_, 'COMMENT': np.str_})
 
 
 def read_catalog(filename, tab_ext=1):
@@ -395,8 +395,8 @@ def read_catalog(filename, tab_ext=1):
         Data table.
 
     """
-    return _read_table(filename, tab_ext, {'INDEX': np.str,
-                                           'FILENAME': np.str})
+    return _read_table(filename, tab_ext, {'INDEX': np.str_,
+                                           'FILENAME': np.str_})
 
 
 def read_wavecat(filename):


### PR DESCRIPTION
Fix #39 

Fix #41 

TODO:
- [x] Wait for Astropy 3.0.3 to be on `conda`, then remove hack and rerun tests.