### PR TITLE
Use PixscaleNotFoundError in thermback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Removed Python 2 support. This version is only compatible with Python 3.5
   or later. [#67]
+- Invalid ``pixscale`` in ``thermback`` calculation now raises
+  ``PixscaleNotFoundError`` instead of ``SynphotError``. [#88]
 
 0.1.1 (2018-07-18)
 ==================

--- a/stsynphot/exceptions.py
+++ b/stsynphot/exceptions.py
@@ -42,3 +42,8 @@ class IncompleteObsmode(GraphtabError):
 class AmbiguousObsmode(GraphtabError):
     """Ambiguous observation mode is not allowed in graph table."""
     pass
+
+
+class PixscaleNotFoundError(SynphotError):
+    """Undefined pixel scale for a given observation mode."""
+    pass

--- a/stsynphot/spectrum.py
+++ b/stsynphot/spectrum.py
@@ -23,6 +23,7 @@ from synphot.spectrum import SourceSpectrum, SpectralElement
 
 # LOCAL
 from . import stio
+from .exceptions import PixscaleNotFoundError
 
 __all__ = ['reset_cache', 'interpolate_spectral_element',
            'ObservationSpectralElement', 'band', 'ebmvx', 'load_vega', 'Vega']
@@ -346,12 +347,12 @@ class ObservationSpectralElement(SpectralElement):
 
         Raises
         ------
-        synphot.exceptions.SynphotError
-            Calculation failed.
+        stsynphot.exceptions.PixscaleNotFoundError
+            Undefined pixel scale for the given observation mode.
 
         """
         if self.obsmode.pixscale is None:
-            raise synexceptions.SynphotError(
+            raise PixscaleNotFoundError(
                 'Undefined pixel scale for {0}.'.format(self.obsmode))
 
         if area is None:

--- a/stsynphot/tests/test_spectrum.py
+++ b/stsynphot/tests/test_spectrum.py
@@ -26,6 +26,7 @@ from synphot.spectrum import SourceSpectrum, SpectralElement
 # LOCAL
 from .. import spectrum
 from ..config import conf
+from ..exceptions import PixscaleNotFoundError
 from ..stio import irafconvert
 
 _IS_PY32 = (sys.version_info >= (3, 2)) & (sys.version_info < (3, 3))
@@ -253,7 +254,7 @@ class TestObservationSpectralElement(object):
         np.testing.assert_allclose(obs1(w), obs2(w))
 
         # No pixel scale
-        with pytest.raises(synexceptions.SynphotError):
+        with pytest.raises(PixscaleNotFoundError):
             obs1.thermback()
 
         # No binset


### PR DESCRIPTION
`SynphotError` is too generic and HST ETC needs something more specific when pixel scale is undefined for thermal background calculations.

ref: [HETC-186](https://jira.stsci.edu/browse/HETC-186) for further discussions.