### PR TITLE
Added 2MASS and WFIRST to Appendix B docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -313,6 +313,10 @@ Bohlin, R. C. & Gilliland, R. L. 2004, AJ, 127, 3508
 
 Calzetti, D., Kinney, A. L., & Storchi-Bergmann, T. 1994, ApJ, 429, 582
 
+.. _stsynphot-ref-cohen2003:
+
+Cohen, M., Wheaton, W. A., & Megeath, S. T. 2003, AJ, 126, 1090
+
 .. _stsynphot-ref-demarchi2004:
 
 De Marchi, G. et al. 2004, ISR ACS 2004-08: Detector Quantum Efficiency and Photometric Zero Points of the ACS (Baltimore, MD: STScI), http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/acs/documentation/instrument-science-reports-isrs/_documents/isr0408.pdf

--- a/docs/stsynphot/appendixb_nonhst.rst
+++ b/docs/stsynphot/appendixb_nonhst.rst
@@ -110,6 +110,44 @@ systems are small:
 * |nonhst_stromgren2| *uvby*
 
 
+.. _stsynphot-nonhst-2mass:
+
+2MASS
+-----
+
+The 2MASS *JHK*:math:`_s` throughputs are taken from :ref:`Cohen et al. (2003) <stsynphot-ref-cohen2003>`.
+These are normalized relative spectral response curves and include the throughputs of all of the 
+appropriate optics from the 2MASS optical system, as well as the atmosphere above the two 2MASS
+telescopes. 
+
+Zero point reference fluxes for 2MASS reproduced from the 
+`IPAC 2MASS website <https://old.ipac.caltech.edu/2mass/releases/allsky/doc/sec6_4a.html>`_ 
+are included here for reference (pay special attention to the units):
+
++-----+--------------------+-----------------+---------------+-----------------------+
+|Band |λ (µm)              |Bandwidth        |Fnu ref        |Flambda ref            |
+|     |                    |(µm)             |(Jy)           |(W/cm^2/µm)            |
++=====+====================+=================+===============+=======================+
+|J    |   1.235 ± 0.006    | 0.162 ± 0.001   | 1594 ± 27.8   | 3.129E-13 ± 5.464E-15 |
++-----+--------------------+-----------------+---------------+-----------------------+
+|H    |   1.662 ± 0.009    | 0.251 ± 0.002   | 1024 ± 20.0   | 1.133E-13 ± 2.212E-15 |
++-----+--------------------+-----------------+---------------+-----------------------+
+|Ks   |   2.159 ± 0.011    | 0.262 ± 0.002   | 666.7 ± 12.6  | 4.283E-14 ± 8.053E-16 |
++-----+--------------------+-----------------+---------------+-----------------------+
+
+To use the 2MASS throughputs:
+
+>>> import stsynphot as stsyn
+>>> bp = stsyn.band('2mass,j')  # doctest: +SKIP
+>>> bp = stsyn.band('2mass,h')  # doctest: +SKIP
+>>> bp = stsyn.band('2mass,ks')  # doctest: +SKIP
+
+(Note: 2MASS throughput curves were added to the TMG file in January 2020. Users must use
+a TMG/TMC file and associated throughput tables delivered after this date to use the 
+2MASS OBSMODEs.)
+
+
+
 .. _stsynphot-nonhst-cousins:
 
 Cousins
@@ -245,6 +283,37 @@ The Stromgren *uvby* throughputs are taken from
 
     >>> import stsynphot as stsyn
     >>> bp = stsyn.band('stromgren,y')  # doctest: +SKIP
+
+
+.. _stsynphot-nonhst-wfirst:
+
+WFIRST
+------
+
+Phase B estimates of the WFIRST integrated system throughputs have been taken from
+the `WFIRST Reference Information <https://wfirst.gsfc.nasa.gov/science/WFIRST_Reference_Information.html>`_ page at GSFC. 
+for more information. For example:
+
+>>> import stsynphot as stsyn
+>>> bp = stsyn.band('wfirst,wfi,f062')  # doctest: +SKIP
+
+Only the Wide Field Instrument (WFI) is currently supported with the following modes:
+
++------------+-----------------------------------------+
+|Description |Keywords                                 |
++============+=========================================+
+|Filter      |f062, f087, f106, f129, f146, f158, f184 |
++------------+-----------------------------------------+
+|Grating     |grism, prism                             |
++------------+-----------------------------------------+
+
+At this time, the estimated throughputs do not differentiate between the different sensor chip assemblies (SCAs).
+SCA-dependent throughputs will be delivered at a later time.
+
+(Note: WFIRST throughput curves were added to the TMG file in January 2020. Users must use
+a TMG/TMC file and associated throughput tables delivered after this date to use the 
+WFIRST OBSMODEs.)
+
 
 
 .. _stsynphot-nonhst-deprecated:


### PR DESCRIPTION
This merge can wait until the TMG and TMC files are updated with the new OBSMODEs.

EDIT: xref spacetelescope/pysynphot#125