### PR TITLE
TST: linkcheck needs matplotlib to avoid warning, handle broken link

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -180,6 +180,7 @@ jobs:
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools sphinx-astropy
+        python -m pip install matplotlib
         python -m pip install -e .
     - name: Docs link check
       run: |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,7 @@ linkcheck_retry = 5
 linkcheck_ignore = ['https://hsthelp.stsci.edu',
                     'http://ssb.stsci.edu',
                     'http://www.stsci.edu',
-                    'https://www.as.arizona.edu/observing']
+                    'https://www.as.arizona.edu/observing',
+                    'https://phoenix.ens-lyon.fr/simulator/index.faces']
 linkcheck_timeout = 180
 linkcheck_anchors = False


### PR DESCRIPTION
Maybe I misunderstood the problem...

Close #119 