### PR TITLE
TST: Undo ignoring Phoenix site in link check

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,7 +137,6 @@ linkcheck_ignore = ['https://hsthelp.stsci.edu',
                     'http://ssb.stsci.edu',
                     'http://www.stsci.edu',
                     'https://www.as.arizona.edu/observing',
-                    'https://phoenix.ens-lyon.fr/simulator/index.faces',
                     'https://wfirst.gsfc.nasa.gov/science/WFIRST_Reference_Information.html']
 linkcheck_timeout = 180
 linkcheck_anchors = False


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stsynphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to un-ignore Phoenix catalog site in link check.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #122 
