### PR TITLE
MNT: Update astropy default branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.
-    devdeps: git+https://github.com/astropy/astropy.git@master#egg=astropy
+    devdeps: git+https://github.com/astropy/astropy.git@main#egg=astropy
     devdeps: git+https://github.com/spacetelescope/synphot_refactor.git@master#egg=synphot
 
     cov: pytest-cov


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to because `astropy` has changed its default branch! You can report issues to @pllim.