### PR TITLE
Updated Roman throughput to Phase C

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,7 @@ linkcheck_ignore = ['https://hsthelp.stsci.edu',
                     'http://www.stsci.edu',
                     'https://www.as.arizona.edu/observing',
                     'http://phoenix.ens-lyon.fr/simulator/index.faces',
-                    'https://wfirst.gsfc.nasa.gov/science/WFIRST_Reference_Information.html',
+                    'https://roman.gsfc.nasa.gov/science/Roman_Reference_Information.html',
                     'https://www.sdss.org']
 linkcheck_timeout = 180
 linkcheck_anchors = False

--- a/docs/stsynphot/appendixb_nonhst.rst
+++ b/docs/stsynphot/appendixb_nonhst.rst
@@ -285,33 +285,31 @@ The Stromgren *uvby* throughputs are taken from
     >>> bp = stsyn.band('stromgren,y')  # doctest: +SKIP
 
 
-.. _stsynphot-nonhst-wfirst:
+.. _stsynphot-nonhst-roman:
 
-WFIRST
+Roman
 ------
 
-Phase B estimates of the WFIRST integrated system throughputs have been taken from
-the `WFIRST Reference Information <https://wfirst.gsfc.nasa.gov/science/WFIRST_Reference_Information.html>`_ page at GSFC. For example:
+Phase C estimates of the Roman integrated system throughputs have been taken from
+the `Roman Reference Information <https://roman.gsfc.nasa.gov/science/Roman_Reference_Information.html>`_ page at GSFC. For example:
 
 >>> import stsynphot as stsyn
->>> bp = stsyn.band('wfirst,wfi,f062')  # doctest: +SKIP
+>>> bp = stsyn.band('roman,wfi,f062')  # doctest: +SKIP
 
 Only the Wide Field Instrument (WFI) is currently supported with the following modes:
 
-+------------+-----------------------------------------+
-|Description |Keywords                                 |
-+============+=========================================+
-|Filter      |f062, f087, f106, f129, f146, f158, f184 |
-+------------+-----------------------------------------+
-|Grating     |grism, prism                             |
-+------------+-----------------------------------------+
++------------+-----------------------------------------------+
+|Description |Keywords                                       |
++============+===============================================+
+|Filter      |f062, f087, f106, f129, w146, f158, f184, f213 |
++------------+-----------------------------------------------+
+|Grating     |grism, grism0, prism                           |
++------------+-----------------------------------------------+
+
+The grism component gives the throughput for the first order grism spectrum. This is the mode that most users should select. The zeroth order grism throughput (grism0) is provided only as a reference.
 
 At this time, the estimated throughputs do not differentiate between the different sensor chip assemblies (SCAs).
 SCA-dependent throughputs will be delivered at a later time.
-
-(Note: WFIRST throughput curves were added to the TMG file in January 2020. Users must use
-a TMG/TMC file and associated throughput tables delivered after this date to use the
-WFIRST OBSMODEs.)
 
 
 

--- a/docs/stsynphot/appendixb_nonhst.rst
+++ b/docs/stsynphot/appendixb_nonhst.rst
@@ -288,7 +288,7 @@ The Stromgren *uvby* throughputs are taken from
 .. _stsynphot-nonhst-roman:
 
 Roman
-------
+-----
 
 Phase C estimates of the Roman integrated system throughputs have been taken from
 the `Roman Reference Information <https://roman.gsfc.nasa.gov/science/Roman_Reference_Information.html>`_ page at GSFC. For example:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stsynphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request updates the documentation in Appendix B for non-HST filters for the Roman Space Telescope. The TMG and TMC files in CRDS have been updated to rename the components to Roman, as well as renaming the F146 filter to W146, and adding the new F213 filter component. The documentation has been updated in this pull request to account for these changes.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
