### PR TITLE
fix for `collections` import deprecation

### DIFF
--- a/stsynphot/commissioning/utils.py
+++ b/stsynphot/commissioning/utils.py
@@ -3,7 +3,7 @@
 # STDLIB
 import os
 import sys
-from collections import Iterable
+from collections.abc import Sized
 
 # THIRD-PARTY
 import numpy as np
@@ -148,7 +148,7 @@ class CommCase:
                          atol=sys.float_info.min):
         """``assert_allclose`` only report percentage but we
         also want to know some extra info conveniently."""
-        if isinstance(actual, Iterable):
+        if isinstance(actual, Sized):
             ntot = len(actual)
         else:
             ntot = 1


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stsynphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

Direct import from `collections` is deprecated in Python 3.10. This causes the environment testing in https://github.com/spacetelescope/spacetelescope-env-distribution to fail:
```
/usr/share/miniconda/envs/spacetelescope-env-Linux-py3.10-latest/lib/python3.10/site-packages/stsynphot/commissioning/utils.py:6: in <module>
[29](https://github.com/spacetelescope/spacetelescope-env-distribution/runs/7429139594?check_suite_focus=true#step:11:30)
    from collections import Iterable
[30](https://github.com/spacetelescope/spacetelescope-env-distribution/runs/7429139594?check_suite_focus=true#step:11:31)
E   ImportError: cannot import name 'Iterable' from 'collections' (/usr/share/miniconda/envs/spacetelescope-env-Linux-py3.10-latest/lib/python3.10/collections/__init__.py)
```
https://github.com/spacetelescope/spacetelescope-env-distribution/runs/7429139594?check_suite_focus=true#step:11:31

The solution is to import from `collections.abc` instead.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
