### PR TITLE
TST: Update Phoenix gap test case

### DIFF
--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -93,11 +93,11 @@ def test_phoenix_gap():
     """
     https://github.com/spacetelescope/stsynphot_refactor/issues/44
     """
-    catalog.grid_to_spec('phoenix', 2700, -1, 5.1)  # OK
+    catalog.grid_to_spec('phoenix', 2200, -1, 5.1)  # OK
     with pytest.raises(exceptions.ParameterOutOfBounds):
-        catalog.grid_to_spec('phoenix', 2700, -0.5, 5.1)
+        catalog.grid_to_spec('phoenix', 2200, -0.5, 5.1)
     with pytest.raises(exceptions.ParameterOutOfBounds):
-        catalog.grid_to_spec('phoenix', 2700, -0.501, 5.1)
+        catalog.grid_to_spec('phoenix', 2200, -0.501, 5.1)
 
 
 def test_grid_to_spec_exceptions_1():


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stsynphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to update Phoenix catalog test. It looks like Redcat has filled out the gaps for 2700 K in the grid but I still see the gap in 2200 K.

Example failure without this patch: https://github.com/spacetelescope/stsynphot_refactor/actions/runs/3785527395

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

c/c @mgennaro @vglaidler since they were involved in the original problem at https://github.com/spacetelescope/pysynphot/issues/68

xref #44 #48