### PR TITLE
Remove test_phoenix_gap because all gaps now seemingly filled

### DIFF
--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -88,18 +88,6 @@ def test_grid_to_spec_bounds_check(t, m, g):
         catalog.grid_to_spec('k93models', t, m, g)
 
 
-@pytest.mark.remote_data
-def test_phoenix_gap():
-    """
-    https://github.com/spacetelescope/stsynphot_refactor/issues/44
-    """
-    catalog.grid_to_spec('phoenix', 2200, -1, 5.1)  # OK
-    with pytest.raises(exceptions.ParameterOutOfBounds):
-        catalog.grid_to_spec('phoenix', 2200, -0.5, 5.1)
-    with pytest.raises(exceptions.ParameterOutOfBounds):
-        catalog.grid_to_spec('phoenix', 2200, -0.501, 5.1)
-
-
 def test_grid_to_spec_exceptions_1():
     """Test other exceptions."""
     # Invalid catalog


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stsynphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

Test added for #44 no longer emits expected warning. I think gaps are filled.

xref https://github.com/spacetelescope/pysynphot/issues/68#issuecomment-1402438980