### PR TITLE
TST: asdf is bumping numpy in oldest deps so we need to pin it

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ deps =
     oldestdeps: numpy==1.18.*
     oldestdeps: scipy==1.3.*
     oldestdeps: astropy==4.3.*
+    oldestdeps: asdf==2.14.*
     oldestdeps: synphot==1.0.*
 
     # The devdeps factor is intended to be used to install the latest developer version


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stsynphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to fix oldest deps failure due to involuntary numpy bump by asdf