### PR TITLE
Updates to allow for custom atmosphere grids (as in old pysynphot).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,8 @@
-1.5.2 (unreleased)
+1.6.0 (unreleased)
 ==================
+
+- ``get_catalog_index()`` now supports custom grid as long as they are
+  formatted and stored properly under ``crgrid$`` directory. [#224]
 
 1.5.1 (2026-03-09)
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ filterwarnings =
     error
     ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
+    ignore:unclosed <ssl\.SSLSocket:ResourceWarning
     ignore:can't resolve package from __spec__:ImportWarning
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:.*Column disp option

--- a/stsynphot/catalog.py
+++ b/stsynphot/catalog.py
@@ -141,18 +141,20 @@ def get_catalog_index(gridname):
     elif gridname == 'phoenix':
         catdir = 'crgridphoenix$'
     else:
-        raise synexceptions.SynphotError(
-            f'{gridname} is not a supported catalog grid.')
+        catdir = 'crgrid$' + gridname
 
     catdir = stio.irafconvert(catdir)
     filename = stio.resolve_filename(catdir, 'catalog.fits')
 
     # If not cached, read from grid catalog and cache it
     if filename not in _CACHE:
-        data = stio.read_catalog(filename)  # EXT 1
-        _CACHE[filename] = [list(map(float, index.split(','))) +
-                            [data['FILENAME'][i]]
-                            for i, index in enumerate(data['INDEX'])]
+        try:
+            data = stio.read_catalog(filename)  # EXT 1
+            _CACHE[filename] = [list(map(float, index.split(','))) +
+                                [data['FILENAME'][i]]
+                                for i, index in enumerate(data['INDEX'])]
+        except FileNotFoundError as e:
+            raise synexceptions.SynphotError(f'{gridname} catalog was not found: {e}')
 
     return _CACHE[filename], catdir
 

--- a/stsynphot/catalog.py
+++ b/stsynphot/catalog.py
@@ -3,6 +3,7 @@
 
 # STDLIB
 import numbers
+from urllib.error import HTTPError
 
 # THIRD-PARTY
 import numpy as np
@@ -154,7 +155,13 @@ def get_catalog_index(gridname):
                                 [data['FILENAME'][i]]
                                 for i, index in enumerate(data['INDEX'])]
         except FileNotFoundError as e:
-            raise synexceptions.SynphotError(f'{gridname} catalog was not found: {e}')
+            raise synexceptions.SynphotError(
+                f'{gridname} catalog was not found: {e}') from e
+        except HTTPError as e:
+            if e.code != 404:
+                raise
+            raise synexceptions.SynphotError(
+                f'{gridname} remote catalog was not found: {e}') from e
 
     return _CACHE[filename], catdir
 

--- a/stsynphot/catalog.py
+++ b/stsynphot/catalog.py
@@ -124,7 +124,9 @@ def get_catalog_index(gridname):
     Parameters
     ----------
     gridname : str
-        See :func:`grid_to_spec`.
+        See :func:`grid_to_spec` for supported grids.
+        Any other input is assumed to be custom grid stored
+        in ``crgrid$`` as expected by :func:`~stsynphot.stio.irafconvert`.
 
     Returns
     -------
@@ -142,7 +144,7 @@ def get_catalog_index(gridname):
     elif gridname == 'phoenix':
         catdir = 'crgridphoenix$'
     else:
-        catdir = 'crgrid$' + gridname
+        catdir = 'crgrid${}'.format(gridname)
 
     catdir = stio.irafconvert(catdir)
     filename = stio.resolve_filename(catdir, 'catalog.fits')
@@ -154,14 +156,9 @@ def get_catalog_index(gridname):
             _CACHE[filename] = [list(map(float, index.split(','))) +
                                 [data['FILENAME'][i]]
                                 for i, index in enumerate(data['INDEX'])]
-        except FileNotFoundError as e:
+        except (FileNotFoundError, HTTPError) as e:
             raise synexceptions.SynphotError(
                 f'{gridname} catalog was not found: {e}') from e
-        except HTTPError as e:
-            if e.code != 404:
-                raise
-            raise synexceptions.SynphotError(
-                f'{gridname} remote catalog was not found: {e}') from e
 
     return _CACHE[filename], catdir
 

--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -124,12 +124,12 @@ class TestCustomCatalog:
                 ('10000,-0.5,1.0', 'BTSettl_2015_test_00002.fits')]
 
         cat_tab = Table(rows=data,
-                    names=['INDEX', 'FILENAME'], 
-                    dtype=['S14', 'S46'])
-        cat_tab.write(os.path.join(custom_dir, 'catalog.fits'), 
-                  format='fits', 
-                  overwrite=True)
-                  
+                        names=['INDEX', 'FILENAME'],
+                        dtype=['S14', 'S46'])
+        cat_tab.write(os.path.join(custom_dir, 'catalog.fits'),
+                      format='fits',
+                      overwrite=True)
+
         self.custom_name = custom_name
         self.custom_dir = custom_dir
 
@@ -149,6 +149,6 @@ class TestCustomCatalog:
 def test_get_catalog_index_invalid_custom():
     # Test whether we get an exception with an invalid catalog name.
 
-    with pytest.raises(synexceptions.SynphotError, match=r'junk catalog was not found'):
+    with pytest.raises(synexceptions.SynphotError,
+                       match=r'junk catalog was not found'):
         catfiles, catdir = catalog.get_catalog_index('junk')
-

--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -4,8 +4,6 @@
 # THIRD-PARTY
 import numpy as np
 import pytest
-import os
-import shutil
 
 # ASTROPY
 from astropy import units as u
@@ -16,7 +14,7 @@ from synphot import exceptions as synexceptions
 from synphot import units
 
 # LOCAL
-from stsynphot import stio, catalog, exceptions
+from stsynphot import conf as stsyn_conf, catalog, exceptions
 
 
 @pytest.mark.remote_data
@@ -109,46 +107,32 @@ def test_grid_to_spec_exceptions_2():
             'k93models', 6440, 0, 4.3 * u.dimensionless_unscaled)
 
 
-@pytest.mark.remote_data
-class TestCustomCatalog:
+def test_get_catalog_index_custom(tmp_path):
     """Test custom catalogs."""
-    def setup_class(self):
-        # Make mock directory for custom catalog.
-        crds_dir = stio.irafconvert('crgrid$')
-        custom_name = 'BTSettl_2015_test'
-        custom_dir = os.path.join(crds_dir, custom_name)
-        os.makedirs(custom_dir, exist_ok=True)
 
-        data = [('10000,-0.5,0.0', 'BTSettl_2015_test_00000.fits'),
-                ('10000,-0.5,0.5', 'BTSettl_2015_test_00001.fits'),
-                ('10000,-0.5,1.0', 'BTSettl_2015_test_00002.fits')]
+    crgrid = tmp_path / "grid"  # As defined in irafshortcuts.txt
+    crgrid.mkdir()
 
-        cat_tab = Table(rows=data,
-                        names=['INDEX', 'FILENAME'],
-                        dtype=['S14', 'S46'])
-        cat_tab.write(os.path.join(custom_dir, 'catalog.fits'),
-                      format='fits',
-                      overwrite=True)
+    # Mock a custom catalog.
+    custom_name = 'BTSettl_2015_test'
+    custom_dir = crgrid / custom_name
+    custom_dir.mkdir()
+    data = [('10000,-0.5,0.0', 'BTSettl_2015_test_00000.fits'),
+            ('10000,-0.5,0.5', 'BTSettl_2015_test_00001.fits'),
+            ('10000,-0.5,1.0', 'BTSettl_2015_test_00002.fits')]
+    cat_tab = Table(rows=data,
+                    names=['INDEX', 'FILENAME'],
+                    dtype=['S14', 'S46'])
+    cat_tab.write(custom_dir / 'catalog.fits',
+                  format='fits', overwrite=True)
 
-        self.custom_name = custom_name
-        self.custom_dir = custom_dir
-
-    def test_get_catalog_index_custom(self):
+    with stsyn_conf.set_temp("rootdir", str(tmp_path)):
         # Test whether we can get a valid catalog path for a custom catalog
-        catfiles, catdir = catalog.get_catalog_index(f'{self.custom_name}')
-
-        assert catdir.endswith(f'{self.custom_name}')
+        catfiles, catdir = catalog.get_catalog_index(custom_name)
+        assert catdir.endswith(custom_name)
         assert len(catfiles) == 3
 
-    def teardown_class(self):
-        # Clean up
-        shutil.rmtree(self.custom_dir)
-
-
-@pytest.mark.remote_data
-def test_get_catalog_index_invalid_custom():
-    # Test whether we get an exception with an invalid catalog name.
-
-    with pytest.raises(synexceptions.SynphotError,
-                       match=r'junk catalog was not found'):
-        catfiles, catdir = catalog.get_catalog_index('junk')
+        # Test whether we get an exception with an invalid catalog name.
+        with pytest.raises(synexceptions.SynphotError,
+                           match='junk catalog was not found'):
+            catfiles, catdir = catalog.get_catalog_index('junk')

--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -104,3 +104,43 @@ def test_grid_to_spec_exceptions_2():
     with pytest.raises(synexceptions.SynphotError):
         catalog.grid_to_spec(
             'k93models', 6440, 0, 4.3 * u.dimensionless_unscaled)
+
+@pytest.mark.remote_data
+def test_get_catalog_index_custom():
+    from stsynphot import stio
+    import os
+    import shutil
+    from astropy.io import fits
+    from astropy.table import Table
+
+    # Make mock directory for custom catalog.
+    crds_dir = stio.irafconvert('crgrid$')
+    custom_name = 'BTSettl_2015_test'
+    custom_dir = os.path.join(crds_dir, custom_name)
+    os.makedirs(custom_dir, exist_ok=True)
+
+    cat_table = Table(rows=[('10000,-0.5,0.0', 'BTSettl_2015_test_00000.fits'),
+                            ('10000,-0.5,0.5', 'BTSettl_2015_test_00001.fits'),
+                            ('10000,-0.5,1.0', 'BTSettl_2015_test_00002.fits')],
+                      names=['INDEX', 'FILENAME'], dtype=['S14', 'S46'])
+    cat_table.write(os.path.join(custom_dir, 'catalog.fits'), format='fits', overwrite=True)
+
+    # Test whether we can get a valid catalog path for a custom catalog
+    catfiles, catdir = catalog.get_catalog_index(f'{custom_name}')
+
+    assert catdir.endswith(f'{custom_name}')
+    assert len(catfiles) == 3
+
+    # Clean up
+    shutil.rmtree(custom_dir)
+
+    return
+
+@pytest.mark.remote_data
+def test_get_catalog_index_invalid_custom():
+    # Test whether we get an exception with an invalid catalog name.
+
+    with pytest.raises(synexceptions.SynphotError):
+        catfiles, catdir = catalog.get_catalog_index('junk')
+
+    return

--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -105,12 +105,12 @@ def test_grid_to_spec_exceptions_2():
         catalog.grid_to_spec(
             'k93models', 6440, 0, 4.3 * u.dimensionless_unscaled)
 
+
 @pytest.mark.remote_data
 def test_get_catalog_index_custom():
     from stsynphot import stio
     import os
     import shutil
-    from astropy.io import fits
     from astropy.table import Table
 
     # Make mock directory for custom catalog.
@@ -119,11 +119,13 @@ def test_get_catalog_index_custom():
     custom_dir = os.path.join(crds_dir, custom_name)
     os.makedirs(custom_dir, exist_ok=True)
 
-    cat_table = Table(rows=[('10000,-0.5,0.0', 'BTSettl_2015_test_00000.fits'),
-                            ('10000,-0.5,0.5', 'BTSettl_2015_test_00001.fits'),
-                            ('10000,-0.5,1.0', 'BTSettl_2015_test_00002.fits')],
-                      names=['INDEX', 'FILENAME'], dtype=['S14', 'S46'])
-    cat_table.write(os.path.join(custom_dir, 'catalog.fits'), format='fits', overwrite=True)
+    cat_tab = Table(rows=[('10000,-0.5,0.0', 'BTSettl_2015_test_00000.fits'),
+                          ('10000,-0.5,0.5', 'BTSettl_2015_test_00001.fits'),
+                          ('10000,-0.5,1.0', 'BTSettl_2015_test_00002.fits')],
+                    names=['INDEX', 'FILENAME'], dtype=['S14', 'S46'])
+    cat_tab.write(os.path.join(custom_dir, 'catalog.fits'), 
+                  format='fits', 
+                  overwrite=True)
 
     # Test whether we can get a valid catalog path for a custom catalog
     catfiles, catdir = catalog.get_catalog_index(f'{custom_name}')
@@ -135,6 +137,7 @@ def test_get_catalog_index_custom():
     shutil.rmtree(custom_dir)
 
     return
+
 
 @pytest.mark.remote_data
 def test_get_catalog_index_invalid_custom():

--- a/stsynphot/tests/test_catalog.py
+++ b/stsynphot/tests/test_catalog.py
@@ -4,16 +4,19 @@
 # THIRD-PARTY
 import numpy as np
 import pytest
+import os
+import shutil
 
 # ASTROPY
 from astropy import units as u
+from astropy.table import Table
 
 # SYNPHOT
 from synphot import exceptions as synexceptions
 from synphot import units
 
 # LOCAL
-from stsynphot import catalog, exceptions
+from stsynphot import stio, catalog, exceptions
 
 
 @pytest.mark.remote_data
@@ -107,43 +110,45 @@ def test_grid_to_spec_exceptions_2():
 
 
 @pytest.mark.remote_data
-def test_get_catalog_index_custom():
-    from stsynphot import stio
-    import os
-    import shutil
-    from astropy.table import Table
+class TestCustomCatalog:
+    """Test custom catalogs."""
+    def setup_class(self):
+        # Make mock directory for custom catalog.
+        crds_dir = stio.irafconvert('crgrid$')
+        custom_name = 'BTSettl_2015_test'
+        custom_dir = os.path.join(crds_dir, custom_name)
+        os.makedirs(custom_dir, exist_ok=True)
 
-    # Make mock directory for custom catalog.
-    crds_dir = stio.irafconvert('crgrid$')
-    custom_name = 'BTSettl_2015_test'
-    custom_dir = os.path.join(crds_dir, custom_name)
-    os.makedirs(custom_dir, exist_ok=True)
+        data = [('10000,-0.5,0.0', 'BTSettl_2015_test_00000.fits'),
+                ('10000,-0.5,0.5', 'BTSettl_2015_test_00001.fits'),
+                ('10000,-0.5,1.0', 'BTSettl_2015_test_00002.fits')]
 
-    cat_tab = Table(rows=[('10000,-0.5,0.0', 'BTSettl_2015_test_00000.fits'),
-                          ('10000,-0.5,0.5', 'BTSettl_2015_test_00001.fits'),
-                          ('10000,-0.5,1.0', 'BTSettl_2015_test_00002.fits')],
-                    names=['INDEX', 'FILENAME'], dtype=['S14', 'S46'])
-    cat_tab.write(os.path.join(custom_dir, 'catalog.fits'), 
+        cat_tab = Table(rows=data,
+                    names=['INDEX', 'FILENAME'], 
+                    dtype=['S14', 'S46'])
+        cat_tab.write(os.path.join(custom_dir, 'catalog.fits'), 
                   format='fits', 
                   overwrite=True)
+                  
+        self.custom_name = custom_name
+        self.custom_dir = custom_dir
 
-    # Test whether we can get a valid catalog path for a custom catalog
-    catfiles, catdir = catalog.get_catalog_index(f'{custom_name}')
+    def test_get_catalog_index_custom(self):
+        # Test whether we can get a valid catalog path for a custom catalog
+        catfiles, catdir = catalog.get_catalog_index(f'{self.custom_name}')
 
-    assert catdir.endswith(f'{custom_name}')
-    assert len(catfiles) == 3
+        assert catdir.endswith(f'{self.custom_name}')
+        assert len(catfiles) == 3
 
-    # Clean up
-    shutil.rmtree(custom_dir)
-
-    return
+    def teardown_class(self):
+        # Clean up
+        shutil.rmtree(self.custom_dir)
 
 
 @pytest.mark.remote_data
 def test_get_catalog_index_invalid_custom():
     # Test whether we get an exception with an invalid catalog name.
 
-    with pytest.raises(synexceptions.SynphotError):
+    with pytest.raises(synexceptions.SynphotError, match=r'junk catalog was not found'):
         catfiles, catdir = catalog.get_catalog_index('junk')
 
-    return


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stsynphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request allows support for custom atmosphere grids as in the old
PYSYNPHOT. This is needed for the SPISEA package. As long as a directory 
exists and contains a catalog.fits file, it should be supported. Tests were 
built to test both successful and invalid cases. 
