### PR TITLE
TST: Ignore weird warning in devdeps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ filterwarnings =
     ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
     ignore:unclosed <ssl\.SSLSocket:ResourceWarning
+    ignore:Implicitly cleaning up:ResourceWarning
     ignore:can't resolve package from __spec__:ImportWarning
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore:.*Column disp option


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/stsynphot_refactor/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to address weird warning that appears in devdeps only

```
_________________________________ test_bb_5000 _________________________________

cls = <class 'astropy.units.format.generic.Generic'>
t = LexToken(UNIT,'flux',1,0)

    @classmethod
    def _get_unit(cls, t: LexToken) -> UnitBase:
        try:
>           return cls._validate_unit(t.value)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^

../../.tox/py314-test-devdeps/lib/python3.14/site-packages/astropy/units/format/base.py:235: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'astropy.units.format.generic.Generic'>, s = 'flux'
deprecations = <DeprecatedUnitAction.WARN: 'warn'>

    @classmethod
    def _validate_unit(
        cls, s: str, deprecations: DeprecatedUnitAction = DeprecatedUnitAction.WARN
    ) -> UnitBase:
        if s in cls._unit_symbols:
            s = cls._unit_symbols[s]
    
        elif not s.isascii():
            if s[0].startswith("°"):
                s = "deg" if len(s) == 1 else "deg_" + s[1:]
            if len(s) > 1 and s[-1] in cls._unit_suffix_symbols:
                s = s[:-1] + cls._unit_suffix_symbols[s[-1]]
            elif s.endswith("R\N{INFINITY}"):
                s = s[:-2] + "Ry"
    
>       return cls._units[s]
               ^^^^^^^^^^^^^
E       KeyError: 'flux'

../../.tox/py314-test-devdeps/lib/python3.14/site-packages/astropy/units/format/generic.py:429: KeyError

During handling of the above exception, another exception occurred:

self = <tempfile._TemporaryFileCloser object at 0x7f5b5ea725d0>

    def __del__(self):
        close_called = self.close_called
        self.cleanup()
        if not close_called:
>           _warnings.warn(self.warn_message, ResourceWarning)
E           ResourceWarning: Implicitly cleaning up <HTTPError 404: 'Not Found'>

/opt/hostedtoolcache/Python/3.14.4/x64/lib/python3.14/tempfile.py:484: ResourceWarning

The above exception was the direct cause of the following exception:

cls = <class '_pytest.runner.CallInfo'>
func = <function call_and_report.<locals>.<lambda> at 0x7f5b5e9e2b90>
when = 'call'
reraise = (<class '_pytest.outcomes.Exit'>, <class 'KeyboardInterrupt'>)

    @classmethod
    def from_call(
        cls,
        func: Callable[[], TResult],
        when: Literal["collect", "setup", "call", "teardown"],
        reraise: type[BaseException] | tuple[type[BaseException], ...] | None = None,
    ) -> CallInfo[TResult]:
        """Call func, wrapping the result in a CallInfo.
    
        :param func:
            The function to call. Called without arguments.
        :type func: Callable[[], _pytest.runner.TResult]
        :param when:
            The phase in which the function is called.
        :param reraise:
            Exception or exceptions that shall propagate if raised by the
            function, instead of being wrapped in the CallInfo.
        """
        excinfo = None
        instant = timing.Instant()
        try:
>           result: TResult | None = func()
                                     ^^^^^^

../../.tox/py314-test-devdeps/lib/python3.14/site-packages/_pytest/runner.py:353: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/_pytest/runner.py:245: in <lambda>
    lambda: runtest_hook(item=item, **kwds),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/pluggy/_hooks.py:512: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/pluggy/_manager.py:120: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/_pytest/logging.py:850: in pytest_runtest_call
    yield
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/pluggy/_callers.py:53: in run_old_style_hookwrapper
    return result.get_result()
           ^^^^^^^^^^^^^^^^^^^
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/pluggy/_callers.py:38: in run_old_style_hookwrapper
    res = yield
          ^^^^^
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/_pytest/capture.py:900: in pytest_runtest_call
    return (yield)
            ^^^^^
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/pluggy/_callers.py:53: in run_old_style_hookwrapper
    return result.get_result()
           ^^^^^^^^^^^^^^^^^^^
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/pluggy/_callers.py:38: in run_old_style_hookwrapper
    res = yield
          ^^^^^
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/_pytest/skipping.py:268: in pytest_runtest_call
    return (yield)
            ^^^^^
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/_pytest/unraisableexception.py:158: in pytest_runtest_call
    collect_unraisable(item.config)
../../.tox/py314-test-devdeps/lib/python3.14/site-packages/_pytest/unraisableexception.py:79: in collect_unraisable
    raise errors[0]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

config = <_pytest.config.Config object at 0x7f5b80fc8ec0>

    def collect_unraisable(config: Config) -> None:
        pop_unraisable = config.stash[unraisable_exceptions].pop
        errors: list[pytest.PytestUnraisableExceptionWarning | RuntimeError] = []
        meta = None
        hook_error = None
        try:
            while True:
                try:
                    meta = pop_unraisable()
                except IndexError:
                    break
    
                if isinstance(meta, BaseException):
                    hook_error = RuntimeError("Failed to process unraisable exception")
                    hook_error.__cause__ = meta
                    errors.append(hook_error)
                    continue
    
                msg = meta.msg
                try:
>                   warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
E                   pytest.PytestUnraisableExceptionWarning: Exception ignored while calling deallocator <function _TemporaryFileCloser.__del__ at 0x7f5b816864b0>: None

../../.tox/py314-test-devdeps/lib/python3.14/site-packages/_pytest/unraisableexception.py:67: PytestUnraisableExceptionWarning
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>
